### PR TITLE
Add domain models for Scheme Manager

### DIFF
--- a/scheme-manager/internal/domain/application/model.go
+++ b/scheme-manager/internal/domain/application/model.go
@@ -1,0 +1,42 @@
+package application
+
+import "time"
+
+// ApplicantInfo contains information about the applicant
+type ApplicantInfo struct {
+	Name           string    `json:"name"`
+	DateOfBirth    time.Time `json:"date_of_birth"`
+	Gender         string    `json:"gender"`
+	Email          string    `json:"email"`
+	Phone          string    `json:"phone"`
+	Address        string    `json:"address"`
+	City           string    `json:"city"`
+	State          string    `json:"state"`
+	Country        string    `json:"country"`
+	ZipCode        string    `json:"zip_code"`
+	EducationLevel string    `json:"education_level"`
+	FamilyIncome   float64   `json:"family_income"`
+}
+
+// Document represents a submitted document
+type Document struct {
+	Type       string     `json:"type"`
+	URL        string     `json:"url"`
+	UploadedAt time.Time  `json:"uploaded_at"`
+	VerifiedAt *time.Time `json:"verified_at,omitempty"`
+	Status     string     `json:"status"` // Pending, Verified, Rejected
+}
+
+// Application represents an application for a scheme
+type Application struct {
+	ID                string        `json:"id"`
+	SchemeID          string        `json:"scheme_id"`
+	ApplicantID       string        `json:"applicant_id"`
+	ApplicantInfo     ApplicantInfo `json:"applicant_info"`
+	Documents         []Document    `json:"documents"`
+	Status            string        `json:"status"`
+	EligibilityStatus string        `json:"eligibility_status"`
+	AppliedAt         time.Time     `json:"applied_at"`
+	UpdatedAt         time.Time     `json:"updated_at"`
+	ProcessedAt       *time.Time    `json:"processed_at,omitempty"`
+}

--- a/scheme-manager/internal/domain/scheme/model.go
+++ b/scheme-manager/internal/domain/scheme/model.go
@@ -1,0 +1,33 @@
+package scheme
+
+import "time"
+
+// EligibilityCriteria defines the criteria for a scheme
+type EligibilityCriteria struct {
+	MinAge             *int     `json:"min_age,omitempty"`
+	MaxAge             *int     `json:"max_age,omitempty"`
+	Gender             []string `json:"gender,omitempty"`
+	Location           []string `json:"location,omitempty"`
+	EducationLevel     []string `json:"education_level,omitempty"`
+	MaxFamilyIncome    *float64 `json:"max_family_income,omitempty"`
+	RequiredDocuments  []string `json:"required_documents,omitempty"`
+	AdditionalCriteria []string `json:"additional_criteria,omitempty"`
+}
+
+// Scheme represents a financial support or scholarship scheme
+type Scheme struct {
+	ID                  string              `json:"id"`
+	Name                string              `json:"name"`
+	Description         string              `json:"description"`
+	OrganizationID      string              `json:"organization_id"`
+	Amount              float64             `json:"amount"`
+	Currency            string              `json:"currency"`
+	StartDate           time.Time           `json:"start_date"`
+	EndDate             time.Time           `json:"end_date"`
+	ApplicationDeadline time.Time           `json:"application_deadline"`
+	MaxBeneficiaries    *int                `json:"max_beneficiaries,omitempty"`
+	EligibilityCriteria EligibilityCriteria `json:"eligibility_criteria"`
+	Status              string              `json:"status"` // Active, Inactive, Draft, Closed
+	CreatedAt           time.Time           `json:"created_at"`
+	UpdatedAt           time.Time           `json:"updated_at"`
+}


### PR DESCRIPTION
# Add domain models for Scheme Manager
Refers #2 , Step 1 towards scheme manager
## Description
This PR adds domain models for the Scheme Manager component, which is part of the ONEST financial support protocol integration. These models will form the foundation for the stateless microservice that will expose APIs for scheme management.

## Changes
- Added `scheme` domain model with the following:
  - `EligibilityCriteria` struct to define eligibility rules for financial support schemes
  - `Scheme` struct to represent a financial support or scholarship scheme with full metadata

- Added `application` domain model with the following:
  - `ApplicantInfo` struct to store applicant details
  - `Document` struct for handling submitted verification documents
  - `Application` struct to represent an application for a specific scheme

## Next Steps
These models are essential for implementing the core functionality requested in issue #2:
- PushSchemes: The `Scheme` model will be used to define schemes with eligibility criteria
- GetApplications: The `Application` model will store applications with their status and documents
- UpdateStatus: Both models include status fields that can be updated through the API